### PR TITLE
empty array ([]) for empty to-many relationships

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    simple-json-api-serializer (1.0.4)
+    simple-json-api-serializer (1.0.8)
       activesupport (~> 4.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -16,7 +16,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.3)
+    minitest (5.9.1)
     rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)

--- a/lib/json_api/relationship_serializer.rb
+++ b/lib/json_api/relationship_serializer.rb
@@ -10,8 +10,8 @@ module JSONApi
       links = serializer.links_for(object, options)
 
       result = {}
-      result[:data]  = data  unless data.nil?  || data.empty?
-      result[:links] = links unless links.nil? || links.empty?
+      result[:data]  = data unless data.nil?
+      result[:links] = links unless links.nil?
 
       if result.empty?
         nil

--- a/spec/lib/relationship_serializer_spec.rb
+++ b/spec/lib/relationship_serializer_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe JSONApi::RelationshipSerializer do
       })
     end
 
+    it 'returns [] when has many relationship has no objects' do
+      object = Post.new(1, [])
+      result = subject.as_json(object, name: :comments, to: :many, data: true, links: false)
+      expect(result).to eq({ data: [] })
+    end
+
     it "can add links to a has many relationship" do
       object = Post.new(1)
       result = subject.as_json(object, name: :comments, to: :many, parent_type: 'posts')


### PR DESCRIPTION
According to [JSON API](http://jsonapi.org/format/#document-resource-object-linkage) an empty array
should be returned for empty to-many relationships.

```
Resource linkage MUST be represented as one of the following:

null for empty to-one relationships.
an empty array ([]) for empty to-many relationships.
a single resource identifier object for non-empty to-one relationships.
an array of resource identifier objects for non-empty to-many relationships.
```