### PR TITLE
return null for empty to-one relationships

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple-json-api-serializer (1.0.9)
+    simple-json-api-serializer (1.0.10)
       activesupport (~> 4.2)
 
 GEM
@@ -45,4 +45,4 @@ DEPENDENCIES
   simple-json-api-serializer!
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/lib/json_api/relationship_serializer.rb
+++ b/lib/json_api/relationship_serializer.rb
@@ -10,8 +10,8 @@ module JSONApi
       links = serializer.links_for(object, options)
 
       result = {}
-      result[:data]  = data unless data.nil?
-      result[:links] = links unless links.nil?
+      result[:data]  = data unless data == false
+      result[:links] = links unless links == false
 
       if result.empty?
         nil
@@ -59,7 +59,7 @@ module JSONApi
       end
 
       def data_for(object, options)
-        return if options[:data] != true
+        return false if options[:data] != true
 
         ids = relationship_for(object, options)
         ids.map { |id| resource_identifier_for(type_for(object, options), id) }
@@ -67,7 +67,7 @@ module JSONApi
       end
 
       def links_for(object, options)
-        return if options[:links] == false
+        return false if options[:links] == false
 
         id   = Utils.canonicalize_id(object.send(options[:id_attribute] || :id))
         type = Utils.canonicalize_attribute_name(options[:name])
@@ -82,14 +82,14 @@ module JSONApi
       end
 
       def data_for(object, options)
-        return if options[:data] == false
+        return false if options[:data] == false
 
         id = relationship_for(object, options)
         resource_identifier_for(type_for(object, options), id)
       end
 
       def links_for(object, options)
-        return if options[:links] != true
+        return false if options[:links] != true
 
         id   = Utils.canonicalize_id(object.send(options[:id_attribute] || :id))
         type = Utils.canonicalize_attribute_name(options[:name])

--- a/lib/json_api/version.rb
+++ b/lib/json_api/version.rb
@@ -1,3 +1,3 @@
 module JSONApi
-  VERSION = '1.0.9'
+  VERSION = '1.0.10'
 end

--- a/spec/lib/relationship_serializer_spec.rb
+++ b/spec/lib/relationship_serializer_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe JSONApi::RelationshipSerializer do
     it "returns nil when the foreign key is nil" do
       object = Article.new(1, nil)
       result = subject.as_json(object, name: :author, to: :one)
-      expect(result).to be nil
+      expect(result).to eq({data: nil})
     end
   end
 end


### PR DESCRIPTION
Adhering to JSON API spec, return `data: null` for empty to-one relationships
(when specifiyng `data: true` is settings).
JSON API spec: http://jsonapi.org/format/#document-resource-object-linkage

Updates gem to version 1.0.10